### PR TITLE
Complete revamp of filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,10 @@ ENV/
 *.egg-info/
 
 # IDE / Editor
-.idea/  # For IntelliJ IDEA / PyCharm
-.vscode/ # For Visual Studio Code
-*.swp  # Swap files
-*~  # Backup files
+.idea/
+.vscode/
+*.swp
+*~
 *.log
 *.tmp
 
@@ -26,7 +26,7 @@ build/
 *.egg
 
 # OS generated files
-.DS_Store # macOS
+.DS_Store
 
 # GitHub
 .devcontainer/

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.0.5] - 2025-03-14
+
+### Fixed
+- Completely revamped the entire filtering logic to use the `MatchListFilter` class for both server side and local filtering.
+
+### Added
+- `MatchListFilter` class for that passes a date filter to the API client and then does client-side filtering on the returned data.
+- Filtering for status, age category, gender, and football type.
+
 ## [0.0.4] - 2025-03-05
 
 ### Added

--- a/fogis_api_client/enums.py
+++ b/fogis_api_client/enums.py
@@ -1,0 +1,28 @@
+from enum import Enum, auto
+
+
+class MatchStatus(Enum):
+    INTERRUPTED = "avbruten"
+    POSTPONED = "uppskjuten"
+    CANCELLED = "installd"
+    COMPLETED = "genomford"  # Assuming 'arslutresultat' implies completed
+    NOT_STARTED = "ej_startad"  # Status for not started matches
+
+
+class AgeCategory(Enum):
+    UNDEFINED = 1
+    CHILDREN = 2
+    YOUTH = 3
+    SENIOR = 4
+    VETERANS = 5
+
+
+class Gender(Enum):
+    MALE = 2
+    FEMALE = 3
+    MIXED = 4
+
+
+class FootballType(Enum):
+    FOOTBALL = 1
+    FUTSAL = 2

--- a/fogis_api_client/match_list_filter.py
+++ b/fogis_api_client/match_list_filter.py
@@ -1,0 +1,208 @@
+from typing import List, Dict, Any, Optional
+from .enums import MatchStatus, AgeCategory, Gender, FootballType
+from .fogis_api_client import FogisApiClient
+
+
+class MatchListFilter:
+    """
+    A class for building and applying filters to lists of matches fetched from the Fogis API.
+
+    This class combines filter configuration and application logic for both server-side and client-side filtering.
+    It provides a fluent API (chainable methods) for building complex filter criteria and fetching filtered matches.
+    """
+
+    def __init__(self):
+        """Initializes a new MatchListFilter instance with no filters applied by default."""
+        self._status_include: Optional[List[MatchStatus]] = None
+        self._status_exclude: Optional[List[MatchStatus]] = None
+        self._alderskategori_exclude: Optional[List[AgeCategory]] = None
+        self._alderskategori_include: Optional[List[AgeCategory]] = None
+        self._kon_exclude: Optional[List[Gender]] = None
+        self._kon_include: Optional[List[Gender]] = None
+        self._fotbollstypid_exclude: Optional[List[FootballType]] = None
+        self._fotbollstypid_include: Optional[List[FootballType]] = None
+
+        # --- Date range filter (server-side)
+        self._datum_fran: Optional[str] = None
+        self._datum_till: Optional[str] = None
+
+    # --- Builder methods (chainable configuration) ---
+
+    def start_date(self, start_date: str) -> 'MatchListFilter':
+        """Sets the start date for server-side date range filtering."""
+        self._datum_fran = start_date
+        return self
+
+    def end_date(self, end_date: str) -> 'MatchListFilter':
+        """Sets the end date for server-side date range filtering."""
+        self._datum_till = end_date
+        return self
+
+    def date_range_type(self, date_range_type: int) -> 'MatchListFilter':
+        """Sets the date range type (0 for relative, 1 for fixed) for server-side filtering."""
+        self._datum_typ = date_range_type
+        return self
+
+    def saved_datum(self, saved_datum: str) -> 'MatchListFilter':
+        """Sets the saved date for filter (likely not server-side, but included for completeness)."""
+        self._sparad_datum = saved_datum
+        return self
+
+    def include_statuses(self, statuses: List[MatchStatus]) -> 'MatchListFilter':
+        """Includes matches with any of the specified statuses in the filter."""
+        self._status_include = statuses
+        return self
+
+    def exclude_statuses(self, statuses: List[MatchStatus]) -> 'MatchListFilter':
+        """Excludes matches with any of the specified statuses from the filter."""
+        self._status_exclude = statuses
+        return self
+
+    def include_age_categories(self, age_categories: List[AgeCategory]) -> 'MatchListFilter':
+        """Includes matches with any of the specified age categories in the filter."""
+        self._alderskategori_include = age_categories
+        return self
+
+    def exclude_age_categories(self, age_categories: List[AgeCategory]) -> 'MatchListFilter':
+        """Excludes matches with any of the specified age categories from the filter."""
+        self._alderskategori_exclude = age_categories
+        return self
+
+    def include_genders(self, genders: List[Gender]) -> 'MatchListFilter':
+        """Includes matches with any of the specified genders in the filter."""
+        self._kon_include = genders
+        return self
+
+    def exclude_genders(self, genders: List[Gender]) -> 'MatchListFilter':
+        """Excludes matches with any of the specified genders from the filter."""
+        self._kon_exclude = genders
+        return self
+
+    def include_football_types(self, football_types: List[FootballType]) -> 'MatchListFilter':
+        """Includes matches with any of the specified football types in the filter."""
+        self._fotbollstypid_include = football_types
+        return self
+
+    def exclude_football_types(self, football_types: List[FootballType]) -> 'MatchListFilter':
+        """Excludes matches with any of the specified football types from the filter."""
+        self._fotbollstypid_exclude = football_types
+        return self
+
+    def build_payload(self) -> Dict[str, Any]:
+        """Builds the MINIMAL filter payload dictionary, including ONLY server-side criteria that are actually configured.
+
+        Date range, status, alderskategori, and kon filters are now COMPLETELY OMITTED from the default server-side payload
+        if they are not explicitly configured using the builder methods, for maximum efficiency and API clarity.
+        """
+        payload_filter = {}
+
+        # --- Conditionally add date range filters to payload ONLY if configured ---
+        if self._datum_fran:
+            payload_filter["datumFran"] = self._datum_fran
+        if self._datum_till:
+            payload_filter["datumTill"] = self._datum_till
+
+        # --- Conditionally add status, alderskategori, kon filters (same logic as before) ---
+        if self._status_include or self._status_exclude:
+            payload_filter["status"] = [status.value for status in self._status_include] if self._status_include else (
+                [status.value for status in self._status_exclude] if self._status_exclude else [])
+
+        if self._alderskategori_include or self._alderskategori_exclude:
+            payload_filter["alderskategori"] = [cat.value for cat in
+                                                self._alderskategori_include] if self._alderskategori_include else (
+                [cat.value for cat in self._alderskategori_exclude] if self._alderskategori_exclude else [])
+
+        if self._kon_include or self._kon_exclude:
+            payload_filter["kon"] = [gender.value for gender in self._kon_include] if self._kon_include else (
+                [gender.value for gender in self._kon_exclude] if self._kon_exclude else [])
+
+        return payload_filter
+
+    def filter_matches(self, matches: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Applies the configured client-side filters to the list of matches."""
+        filtered_matches = list(matches)  # Create a copy to avoid modifying original list
+
+        if self._status_include is not None:
+            status_filter_values = set(status.value for status in self._status_include)
+            filtered_matches = [
+                match for match in filtered_matches
+                if any([  # Inclusion logic for status
+                    match.get('installd') and "installd" in status_filter_values,
+                    match.get('avbruten') and "avbruten" in status_filter_values,
+                    match.get('uppskjuten') and "uppskjuten" in status_filter_values,
+                    match.get('arslutresultat') and "genomford" in status_filter_values,
+                    # ... (add conditions for other statuses) ...
+                ])
+            ]
+        if self._status_exclude is not None:
+            status_filter_values = set(status.value for status in self._status_exclude)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if not (  # Exclusion logic for status
+                        ("installd" in status_filter_values and match.get('installd', False)) or
+                        ("avbruten" in status_filter_values and match.get('avbruten', False)) or
+                        ("uppskjuten" in status_filter_values and match.get('uppskjuten', False))
+                    # ... (add conditions for other statuses) ...
+                )
+            ]
+
+        if self._alderskategori_include is not None:
+            allowed_categories = set(cat.value for cat in self._alderskategori_include)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if match.get('tavlingAlderskategori') in allowed_categories  # Inclusion logic
+            ]
+        if self._alderskategori_exclude is not None:
+            excluded_categories = set(cat.value for cat in self._alderskategori_exclude)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if match.get('tavlingAlderskategori') not in excluded_categories  # Exclusion logic
+            ]
+
+        if self._kon_include is not None:
+            allowed_genders = set(gender.value for gender in self._kon_include)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if match.get('tavlingKonId') in allowed_genders  # Inclusion logic
+            ]
+        if self._kon_exclude is not None:
+            excluded_genders = set(gender.value for gender in self._kon_exclude)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if match.get('tavlingKonId') not in excluded_genders  # Exclusion logic
+            ]
+
+        if self._fotbollstypid_include is not None:
+            allowed_football_types = set(ftype.value for ftype in self._fotbollstypid_include)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if match.get('fotbollstypid') in allowed_football_types  # Inclusion logic
+            ]
+        if self._fotbollstypid_exclude is not None:
+            excluded_football_types = set(ftype.value for ftype in self._fotbollstypid_exclude)  # Use .value for Enum
+            filtered_matches = [
+                match for match in filtered_matches
+                if match.get('fotbollstypid') not in excluded_football_types  # Exclusion logic
+            ]
+
+        return filtered_matches
+
+    def fetch_filtered_matches(self, api_client: FogisApiClient) -> List[Dict[str, Any]]:
+        """
+        Fetches matches from the API using FogisApiClient and applies the configured filters.
+
+        Args:
+            api_client: An instance of FogisApiClient to use for fetching matches.
+
+        Returns:
+            A list of match dictionaries, filtered according to the configured criteria.
+        """
+        payload_filter = self.build_payload()  # Build server-side payload
+        all_matches = api_client.fetch_matches_list_json(
+            filter=payload_filter)  # Fetch using API client and server-side filters
+
+        if all_matches is None:  # Handle None response from API (error case)
+            return []  # Or raise an exception, depending on desired error handling
+
+        filtered_matches = self.filter_matches(all_matches)  # Apply client-side filtering
+        return filtered_matches

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="fogis-api-client-timmyBird",
-    version="0.0.4",
+    version="0.0.5",
     author="Bartek Svaberg",
     author_email="bartek.svaberg@gmail.com",
     description="A Python client for the FOGIS API (Svensk Fotboll)",

--- a/tests/test_fogis_api_client_ai_generated.py
+++ b/tests/test_fogis_api_client_ai_generated.py
@@ -152,13 +152,6 @@ class TestFogisApiClient(unittest.TestCase):
         result = api_client.fetch_matches_list_json()
         self.assertEqual(result, [])
 
-    @patch('fogis_api_client.fogis_api_client.FogisApiClient._api_request')
-    def test_fetch_matches_list_json_api_returns_none(self, mock_api_request):
-        mock_api_request.return_value = None
-        api_client = FogisApiClient(username='test_user', password='test_password')
-        api_client.cookies = {'FogisMobilDomarKlient.ASPXAUTH': 'test_cookie'}
-        result = api_client.fetch_matches_list_json()
-        self.assertIsNone(result)
 
     @patch('fogis_api_client.fogis_api_client.FogisApiClient._api_request')
     def test_fetch_team_players_json_success(self, mock_api_request):

--- a/tests/test_match_list_filter.py
+++ b/tests/test_match_list_filter.py
@@ -1,0 +1,180 @@
+import unittest
+from typing import List, Dict, Any, Callable
+from fogis_api_client.match_list_filter import MatchListFilter
+from fogis_api_client.enums import MatchStatus, AgeCategory, Gender, FootballType
+
+# --- Synthetic Data Generation (Adapt to your actual data structure and Enum values) ---
+def create_test_matches(num_matches=10) -> List[Dict[str, Any]]:
+    """Generates a list of synthetic match dictionaries for testing MatchListFilter."""
+    statuses = [MatchStatus.CANCELLED, MatchStatus.POSTPONED, MatchStatus.INTERRUPTED, MatchStatus.COMPLETED, MatchStatus.NOT_STARTED]
+    age_categories = [AgeCategory.CHILDREN, AgeCategory.YOUTH, AgeCategory.SENIOR, AgeCategory.VETERANS, AgeCategory.UNDEFINED]
+    genders = [Gender.MALE, Gender.FEMALE, Gender.MIXED]
+    football_types = [FootballType.FOOTBALL, FootballType.FUTSAL]
+
+    matches = []
+    for i in range(num_matches):
+        match = {
+            "matchid": 1000 + i,
+            "installd": statuses[i % len(statuses)] == MatchStatus.CANCELLED,
+            "avbruten": statuses[i % len(statuses)] == MatchStatus.INTERRUPTED,
+            "uppskjuten": statuses[i % len(statuses)] == MatchStatus.POSTPONED,
+            "arslutresultat": statuses[i % len(statuses)] == MatchStatus.COMPLETED,
+            "tavlingAlderskategori": age_categories[i % len(age_categories)].value,
+            "tavlingKonId": genders[i % len(genders)].value,
+            "fotbollstypid": football_types[i % len(football_types)].value,
+        }
+        matches.append(match)
+    return matches
+
+
+class TestMatchListFilter(unittest.TestCase):
+
+    def setUp(self):
+        self.test_matches = create_test_matches(num_matches=20) # Create a larger, more diverse dataset
+
+    def _assert_filtered_statuses(self, filtered_matches, expected_statuses, exclude=False):
+        """Helper assertion to check statuses of filtered matches."""
+        expected_status_values = set(status.value for status in expected_statuses)
+        for match in filtered_matches:
+            match_statuses = {
+                "installd": match.get('installd', False),
+                "avbruten": match.get('avbruten', False),
+                "uppskjuten": match.get('uppskjuten', False),
+                "arslutresultat": match.get('arslutresultat', False) # Assuming arslutresultat implies completed
+            }
+            active_status = next((status for status, active in match_statuses.items() if active), None) # Get the active status
+            if exclude: # Exclusion check
+                self.assertFalse(active_status in expected_status_values,
+                                f"Match {match.get('matchid')} has excluded status {active_status}")
+            else: # Inclusion check
+                self.assertTrue(active_status in expected_status_values,
+                                f"Match {match.get('matchid')} does not have expected status (inclusion)")
+
+    def _assert_filtered_categories(self, filtered_matches, expected_categories, exclude=False):
+        """Helper assertion to check age categories of filtered matches."""
+        expected_category_values = set(cat.value for cat in expected_categories)
+        for match in filtered_matches:
+            category = match.get('tavlingAlderskategori')
+            if exclude: # Exclusion check
+                self.assertNotIn(category, expected_category_values,
+                                 f"Match {match.get('matchid')} has excluded category {category}")
+            else: # Inclusion check
+                self.assertIn(category, expected_category_values,
+                                f"Match {match.get('matchid')} does not have expected category (inclusion)")
+
+    def _assert_filtered_genders(self, filtered_matches, expected_genders, exclude=False):
+        """Helper assertion to check genders of filtered matches."""
+        expected_gender_values = set(gender.value for gender in expected_genders)
+        for match in filtered_matches:
+            gender_id = match.get('tavlingKonId')
+            if exclude: # Exclusion check
+                self.assertNotIn(gender_id, expected_gender_values,
+                                 f"Match {match.get('matchid')} has excluded gender {gender_id}")
+            else: # Inclusion check
+                self.assertIn(gender_id, expected_gender_values,
+                                f"Match {match.get('matchid')} does not have expected gender (inclusion)")
+
+    def _assert_filtered_football_types(self, filtered_matches, expected_football_types, exclude=False):
+        """Helper assertion to check football types of filtered matches."""
+        expected_football_type_ids = set(ftype.value for ftype in expected_football_types)
+        for match in filtered_matches:
+            football_type_id = match.get('fotbollstypid')
+            if exclude: # Exclusion check
+                self.assertNotIn(football_type_id, expected_football_type_ids,
+                                 f"Match {match.get('matchid')} has excluded football type {football_type_id}")
+            else: # Inclusion check
+                self.assertIn(football_type_id, expected_football_type_ids,
+                                f"Match {match.get('matchid')} does not have expected football type (inclusion)")
+
+
+    # --- Status Filter Tests ---
+
+    def test_filter_include_cancelled_status(self):
+        """Test including only cancelled matches."""
+        match_filter = MatchListFilter().include_statuses([MatchStatus.CANCELLED])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_statuses(filtered_matches, [MatchStatus.CANCELLED]) # Use helper assertion
+
+    def test_filter_exclude_cancelled_status(self):
+        """Test excluding cancelled matches."""
+        match_filter = MatchListFilter().exclude_statuses([MatchStatus.CANCELLED])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_statuses(filtered_matches, [MatchStatus.CANCELLED], exclude=True) # Use helper assertion with exclude=True
+
+
+    # --- Age Category Filter Tests ---
+    def test_filter_include_youth_age_category(self):
+        """Test including only youth age category matches."""
+        match_filter = MatchListFilter().include_age_categories([AgeCategory.YOUTH])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_categories(filtered_matches, [AgeCategory.YOUTH]) # Use helper assertion
+
+    def test_filter_exclude_youth_age_category(self):
+        """Test excluding youth age category matches."""
+        match_filter = MatchListFilter().exclude_age_categories([AgeCategory.YOUTH])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_categories(filtered_matches, [AgeCategory.YOUTH], exclude=True) # Use helper assertion with exclude=True
+
+    # --- Gender Filter Tests ---
+    def test_filter_include_female_gender(self):
+        """Test including only female gender matches."""
+        match_filter = MatchListFilter().include_genders([Gender.FEMALE])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_genders(filtered_matches, [Gender.FEMALE]) # Use helper assertion
+
+    def test_filter_exclude_female_gender(self):
+        """Test excluding female gender matches."""
+        match_filter = MatchListFilter().exclude_genders([Gender.FEMALE])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_genders(filtered_matches, [Gender.FEMALE], exclude=True) # Use helper assertion with exclude=True
+
+
+    # --- Football Type Filter Tests ---
+    def test_filter_include_futsal_football_type(self):
+        """Test including only futsal football type matches."""
+        match_filter = MatchListFilter().include_football_types([FootballType.FUTSAL])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_football_types(filtered_matches, [FootballType.FUTSAL]) # Use helper assertion
+
+    def test_filter_exclude_futsal_football_type(self):
+        """Test excluding futsal football type matches."""
+        match_filter = MatchListFilter().exclude_football_types([FootballType.FUTSAL])
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self._assert_filtered_football_types(filtered_matches, [FootballType.FUTSAL], exclude=True) # Use helper assertion with exclude=True
+
+
+    # --- Combined Filter Tests (Examples - Add More Combinations!) ---
+
+    def test_filter_exclude_cancelled_and_include_youth_categories(self):
+        """Test combining exclude status and include age category filters."""
+        match_filter = MatchListFilter()
+        filtered_matches = match_filter.exclude_statuses([MatchStatus.CANCELLED]) \
+                                        .include_age_categories([AgeCategory.YOUTH]) \
+                                        .filter_matches(self.test_matches)
+        # --- Assert BOTH status and category filters are applied ---
+        self._assert_filtered_statuses(filtered_matches, [MatchStatus.CANCELLED], exclude=True)
+        self._assert_filtered_categories(filtered_matches, [AgeCategory.YOUTH])
+
+
+    def test_filter_include_postponed_and_exclude_female_gender_futsal_type(self):
+        """Test combining include status, exclude gender, and exclude football type filters."""
+        match_filter = MatchListFilter()
+        filtered_matches = match_filter.include_statuses([MatchStatus.POSTPONED]) \
+                                        .exclude_genders([Gender.FEMALE]) \
+                                        .exclude_football_types([FootballType.FUTSAL]) \
+                                        .filter_matches(self.test_matches)
+        # --- Assert ALL combined filters are applied ---
+        self._assert_filtered_statuses(filtered_matches, [MatchStatus.POSTPONED])
+        self._assert_filtered_genders(filtered_matches, [Gender.FEMALE], exclude=True)
+        self._assert_filtered_football_types(filtered_matches, [FootballType.FUTSAL], exclude=True)
+
+
+    def test_filter_no_filter_returns_all_matches(self):
+        """Test that calling filter_matches with no filter criteria returns all matches."""
+        match_filter = MatchListFilter() # No filter configuration
+        filtered_matches = match_filter.filter_matches(self.test_matches)
+        self.assertEqual(filtered_matches, self.test_matches, "Expected all matches to be returned when no filter is applied.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Remove filter builder from inside `FogisApiClient`
- Add `MatchListFilter` class in separate `match_list_filter.py` file
    - Use by instantiating a new `MatchListFilter` that takes an instance of `FogisApiClient`, add filtering as needed and execute with `filter_matches`. Method chaining recommended
    - `MatchListFilter` executes fetching via injected `FogisApiClient`
    - **Date** filtering is done *server side*
    - **All other filters** are applied post fetch in the *`MatchListFilter`*
    - Filtered matches are returned