### PR TITLE
Implement mark as done

### DIFF
--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -331,3 +331,34 @@ class FogisApiClient:
         else:
             print("No match events found to clear.")
             return False
+    def mark_reporting_finished(self, match_id):
+        """
+        Mark a match report as completed/finished in the FOGIS system.
+        
+        This is the final step in the referee reporting workflow that finalizes 
+        the match report and submits it officially.
+        
+        Args:
+            match_id (str): The ID of the match to mark as finished
+            
+        Returns:
+            dict: The response from the FOGIS API
+            
+        Raises:
+            FogisAPIRequestError: If there's an error with the API request
+            
+        Example:
+            >>> client = FogisApiClient(username, password)
+            >>> client.login()
+            >>> result = client.mark_reporting_finished(match_id="123456")
+            >>> print(f"Report marked as finished: {result['success']}")
+        """
+        # Validate match_id
+        if not match_id:
+            raise ValueError("match_id cannot be empty")
+            
+        payload = {"matchid": match_id}
+        return self._api_request(
+            url=f"{FogisApiClient.BASE_URL}/Fogis/Match/SparaMatchGodkannDomarrapport",
+            payload=payload
+        )

--- a/tests/test_mark_reporting_finished.py
+++ b/tests/test_mark_reporting_finished.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import patch, MagicMock, Mock
+import requests
+
+from fogis_api_client.fogis_api_client import FogisApiClient, FogisLoginError, FogisAPIRequestError
+
+
+class MockResponse:
+    """
+    A mock class to simulate requests.Response for testing.
+    """
+
+    def __init__(self, json_data, status_code):
+        self._json_data = MagicMock(return_value=json_data)
+        self.status_code = status_code
+
+    def json(self):
+        returned_json_data = self._json_data()
+        return returned_json_data
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            raise requests.exceptions.HTTPError(f"Mocked HTTP Error: {self.status_code}", response=None)
+
+
+class TestMarkReportingFinished(unittest.TestCase):
+    """Test cases for the mark_reporting_finished functionality."""
+
+    def setUp(self):
+        self.client = FogisApiClient("testuser", "testpassword")
+        
+        # Create a mock session
+        mock_session = Mock()
+        mock_session.get = MagicMock()
+        mock_session.post = MagicMock()
+        mock_session.cookies = MagicMock(spec=dict)
+        mock_session.cookies.set = MagicMock()
+        
+        self.client.session = mock_session
+        self.client.cookies = {'FogisMobilDomarKlient.ASPXAUTH': 'mock_auth_cookie'}  # Simulate being logged in
+
+    def test_mark_reporting_finished_success(self):
+        """Test that mark_reporting_finished works correctly with a valid match ID."""
+        # Mock the API response
+        mock_api_response = MockResponse(json_data={'d': {'success': True}}, status_code=200)
+        self.client.session.post.return_value = mock_api_response
+        
+        # Call mark_reporting_finished
+        match_id = "123456"
+        response_data = self.client.mark_reporting_finished(match_id)
+        
+        # Verify the API request was made
+        self.client.session.post.assert_called_once()
+        
+        # Check the URL and payload
+        args, kwargs = self.client.session.post.call_args
+        url = args[0]  # The URL is the first positional argument
+        self.assertIn("SparaMatchGodkannDomarrapport", url)
+        self.assertEqual({"matchid": match_id}, kwargs['json'])
+        
+        # Verify the response data
+        self.assertTrue(response_data['success'])
+
+    def test_mark_reporting_finished_empty_match_id(self):
+        """Test that mark_reporting_finished raises ValueError with an empty match ID."""
+        # Call mark_reporting_finished with an empty match ID
+        with self.assertRaises(ValueError) as context:
+            self.client.mark_reporting_finished("")
+        
+        self.assertIn("match_id cannot be empty", str(context.exception))
+        
+        # Verify the API request was not made
+        self.client.session.post.assert_not_called()
+
+    def test_mark_reporting_finished_api_error(self):
+        """Test that mark_reporting_finished handles API errors correctly."""
+        # Mock the API response to simulate an error
+        mock_api_response = MockResponse(json_data={'d': {'error': 'Some API error'}}, status_code=400)
+        self.client.session.post.return_value = mock_api_response
+        mock_api_response.raise_for_status = MagicMock(side_effect=requests.exceptions.HTTPError("Mocked HTTP Error: 400"))
+        
+        # Call mark_reporting_finished
+        match_id = "123456"
+        
+        # Verify that FogisAPIRequestError is raised
+        with self.assertRaises(FogisAPIRequestError) as context:
+            self.client.mark_reporting_finished(match_id)
+        
+        # Verify the API request was made
+        self.client.session.post.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #9

## Description
This PR implements the ability to mark a match report as completed/finished in the FOGIS system, which is an important step in the referee reporting workflow.

## Changes
- Added  method to FogisApiClient
- Added tests for the new functionality
- Implemented proper error handling and validation

## Testing
- Added new tests specifically for the mark_reporting_finished functionality
- All existing tests pass with the new implementation