### PR TITLE
Add more endpoints to the HTTP wrapper (Issue #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,35 @@ For more details on the development environment, see [README.dev.md](README.dev.
 
 The HTTP API wrapper provides the following endpoints:
 
+##### Basic Endpoints
 - `GET /` - Returns a test JSON response
 - `GET /hello` - Returns a simple hello world message
+
+##### Match Endpoints
 - `GET /matches` - Returns a list of matches
+- `POST /matches/filter` - Returns a filtered list of matches based on provided criteria
 - `GET /match/<match_id>` - Returns details for a specific match
+- `GET /match/<match_id>/result` - Returns result information for a specific match
+- `GET /match/<match_id>/officials` - Returns officials information for a specific match
+- `POST /match/<match_id>/finish` - Marks a match report as completed/finished
+
+##### Match Events Endpoints
+- `GET /match/<match_id>/events` - Returns events for a specific match
+- `POST /match/<match_id>/events` - Reports a new event for a match
+- `POST /match/<match_id>/events/clear` - Clears all events for a match
+
+##### Team Endpoints
+- `GET /team/<team_id>/players` - Returns player information for a specific team
+- `GET /team/<team_id>/officials` - Returns officials information for a specific team
+
+##### Filter Parameters
+The `/matches/filter` endpoint accepts the following parameters in the request body (JSON):
+- `from_date` - Start date for filtering matches (format: YYYY-MM-DD)
+- `to_date` - End date for filtering matches (format: YYYY-MM-DD)
+- `status` - Match status (e.g., "upcoming", "completed")
+- `age_category` - Age category for filtering matches
+- `gender` - Gender for filtering matches
+- `football_type` - Type of football (e.g., "indoor", "outdoor")
 
 ---
 #### Contributing

--- a/tests/test_http_wrapper.py
+++ b/tests/test_http_wrapper.py
@@ -19,15 +19,23 @@ class TestHttpWrapper(unittest.TestCase):
         self.app = fogis_api_client_http_wrapper.app
         self.app.config['TESTING'] = True
         self.client = self.app.test_client()
-        
+
         # Mock the FogisApiClient
         self.mock_fogis_client = Mock()
         fogis_api_client_http_wrapper.client = self.mock_fogis_client
-        
+
         # Set up mock responses
         self.mock_fogis_client.hello_world.return_value = "Hello, brave new world!"
         self.mock_fogis_client.fetch_matches_list_json.return_value = [{"id": "1", "home_team": "Team A", "away_team": "Team B"}]
-        self.mock_fogis_client.fetch_match_json.return_value = {"id": "123", "home_team": "Team A", "away_team": "Team B"}
+        self.mock_fogis_client.fetch_match_json.return_value = {"id": "123", "home_team": "Team A", "away_team": "Team B", "events": [{"id": "1", "type": "goal"}]}
+        self.mock_fogis_client.fetch_match_result_json.return_value = {"id": "123", "home_score": 2, "away_score": 1}
+        self.mock_fogis_client.fetch_match_events_json.return_value = [{"id": "1", "type": "goal", "player": "John Doe"}]
+        self.mock_fogis_client.fetch_match_officials_json.return_value = [{"id": "1", "name": "Jane Smith", "role": "Referee"}]
+        self.mock_fogis_client.fetch_team_players_json.return_value = [{"id": "1", "name": "John Doe", "position": "Forward"}]
+        self.mock_fogis_client.fetch_team_officials_json.return_value = [{"id": "1", "name": "Coach Smith", "role": "Coach"}]
+        self.mock_fogis_client.report_match_event.return_value = {"status": "success"}
+        self.mock_fogis_client.clear_match_events.return_value = {"status": "success"}
+        self.mock_fogis_client.mark_reporting_finished.return_value = {"success": True}
 
     def test_hello_endpoint(self):
         """Test the /hello endpoint."""
@@ -47,10 +55,10 @@ class TestHttpWrapper(unittest.TestCase):
         """Test the /matches endpoint."""
         # Set up the mock
         mock_fetch.return_value = [{"id": "1", "home_team": "Team A", "away_team": "Team B"}]
-        
+
         # Call the endpoint
         response = self.client.get('/matches')
-        
+
         # Verify the response
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, [{"id": "1", "home_team": "Team A", "away_team": "Team B"}])
@@ -61,10 +69,10 @@ class TestHttpWrapper(unittest.TestCase):
         """Test the /match/<match_id> endpoint."""
         # Set up the mock
         mock_fetch.return_value = {"id": "123", "home_team": "Team A", "away_team": "Team B"}
-        
+
         # Call the endpoint
         response = self.client.get('/match/123')
-        
+
         # Verify the response
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, {"id": "123", "home_team": "Team A", "away_team": "Team B"})
@@ -75,15 +83,186 @@ class TestHttpWrapper(unittest.TestCase):
         """Test the /match/<match_id> endpoint with an error."""
         # Set up the mock to raise an exception
         mock_fetch.side_effect = Exception("Test error")
-        
+
         # Call the endpoint
         response = self.client.get('/match/123')
-        
+
         # Verify the response
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.json, {"error": "Test error"})
         mock_fetch.assert_called_once_with("123")
 
+    @patch('fogis_api_client_http_wrapper.client.fetch_matches_list_json')
+    def test_matches_endpoint_error(self, mock_fetch):
+        """Test the /matches endpoint with an error."""
+        # Set up the mock to raise an exception
+        mock_fetch.side_effect = Exception("Test error")
+
+        # Call the endpoint
+        response = self.client.get('/matches')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json, {"error": "Test error"})
+        mock_fetch.assert_called_once()
+
+    def test_invalid_endpoint(self):
+        """Test accessing an invalid endpoint."""
+        response = self.client.get('/invalid-endpoint')
+        self.assertEqual(response.status_code, 404)
+
+    def test_signal_handler(self):
+        """Test the signal handler function."""
+        # This is a simple test to ensure the function exists and can be called
+        # We can't easily test the actual signal handling without complex mocking
+        self.assertTrue(callable(fogis_api_client_http_wrapper.signal_handler))
+
+    @patch('fogis_api_client_http_wrapper.client.fetch_match_result_json')
+    def test_match_result_endpoint(self, mock_fetch):
+        """Test the /match/<match_id>/result endpoint."""
+        # Set up the mock
+        mock_fetch.return_value = {"id": "123", "home_score": 2, "away_score": 1}
+
+        # Call the endpoint
+        response = self.client.get('/match/123/result')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"id": "123", "home_score": 2, "away_score": 1})
+        mock_fetch.assert_called_once_with("123")
+
+    @patch('fogis_api_client_http_wrapper.client.fetch_match_events_json')
+    def test_match_events_endpoint(self, mock_fetch):
+        """Test the /match/<match_id>/events GET endpoint."""
+        # Set up the mock
+        mock_fetch.return_value = [{"id": "1", "type": "goal", "player": "John Doe"}]
+
+        # Call the endpoint
+        response = self.client.get('/match/123/events')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, [{"id": "1", "type": "goal", "player": "John Doe"}])
+        mock_fetch.assert_called_once_with("123")
+
+    @patch('fogis_api_client_http_wrapper.client.report_match_event')
+    def test_report_match_event_endpoint(self, mock_report):
+        """Test the /match/<match_id>/events POST endpoint."""
+        # Set up the mock
+        mock_report.return_value = {"status": "success"}
+
+        # Call the endpoint
+        event_data = {"type": "goal", "player": "John Doe"}
+        response = self.client.post('/match/123/events', json=event_data)
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"status": "success"})
+
+        # Verify that matchid was added to the event data
+        expected_data = {"type": "goal", "player": "John Doe", "matchid": "123"}
+        mock_report.assert_called_once_with(expected_data)
+
+    def test_report_match_event_endpoint_no_data(self):
+        """Test the /match/<match_id>/events POST endpoint with no data."""
+        # Call the endpoint with no JSON data
+        response = self.client.post('/match/123/events')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json, {"error": "No event data provided"})
+
+    @patch('fogis_api_client_http_wrapper.client.clear_match_events')
+    def test_clear_match_events_endpoint(self, mock_clear):
+        """Test the /match/<match_id>/events/clear endpoint."""
+        # Set up the mock
+        mock_clear.return_value = {"status": "success"}
+
+        # Call the endpoint
+        response = self.client.post('/match/123/events/clear')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"status": "success"})
+        mock_clear.assert_called_once_with("123")
+
+    @patch('fogis_api_client_http_wrapper.client.fetch_match_officials_json')
+    def test_match_officials_endpoint(self, mock_fetch):
+        """Test the /match/<match_id>/officials endpoint."""
+        # Set up the mock
+        mock_fetch.return_value = [{"id": "1", "name": "Jane Smith", "role": "Referee"}]
+
+        # Call the endpoint
+        response = self.client.get('/match/123/officials')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, [{"id": "1", "name": "Jane Smith", "role": "Referee"}])
+        mock_fetch.assert_called_once_with("123")
+
+    @patch('fogis_api_client_http_wrapper.client.fetch_team_players_json')
+    def test_team_players_endpoint(self, mock_fetch):
+        """Test the /team/<team_id>/players endpoint."""
+        # Set up the mock
+        mock_fetch.return_value = [{"id": "1", "name": "John Doe", "position": "Forward"}]
+
+        # Call the endpoint
+        response = self.client.get('/team/456/players')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, [{"id": "1", "name": "John Doe", "position": "Forward"}])
+        mock_fetch.assert_called_once_with("456")
+
+    @patch('fogis_api_client_http_wrapper.client.fetch_team_officials_json')
+    def test_team_officials_endpoint(self, mock_fetch):
+        """Test the /team/<team_id>/officials endpoint."""
+        # Set up the mock
+        mock_fetch.return_value = [{"id": "1", "name": "Coach Smith", "role": "Coach"}]
+
+        # Call the endpoint
+        response = self.client.get('/team/456/officials')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, [{"id": "1", "name": "Coach Smith", "role": "Coach"}])
+        mock_fetch.assert_called_once_with("456")
+
+    @patch('fogis_api_client_http_wrapper.client.mark_reporting_finished')
+    def test_finish_match_report_endpoint(self, mock_finish):
+        """Test the /match/<match_id>/finish endpoint."""
+        # Set up the mock
+        mock_finish.return_value = {"success": True}
+
+        # Call the endpoint
+        response = self.client.post('/match/123/finish')
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"success": True})
+        mock_finish.assert_called_once_with("123")
+
+    @patch('fogis_api_client_http_wrapper.MatchListFilter')
+    def test_filtered_matches_endpoint(self, mock_filter_class):
+        """Test the /matches/filter endpoint."""
+        # Set up the mock
+        mock_filter_instance = mock_filter_class.return_value
+        mock_filter_instance.fetch_filtered_matches.return_value = [
+            {"id": "1", "home_team": "Team A", "away_team": "Team B"}
+        ]
+
+        # Call the endpoint with filter data
+        filter_data = {"from_date": "2023-01-01", "status": "upcoming"}
+        response = self.client.post('/matches/filter', json=filter_data)
+
+        # Verify the response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, [{"id": "1", "home_team": "Team A", "away_team": "Team B"}])
+
+        # Verify that the filter properties were set correctly
+        self.assertEqual(mock_filter_instance.from_date, "2023-01-01")
+        self.assertEqual(mock_filter_instance.status, "upcoming")
+        mock_filter_instance.fetch_filtered_matches.assert_called_once_with(fogis_api_client_http_wrapper.client)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
This PR adds several new endpoints to the HTTP wrapper to expose more functionality from the underlying FogisApiClient.

## New Endpoints Added
-  - Fetches officials information for a specific match
-  - Fetches player information for a specific team
-  - Fetches officials information for a specific team
-  - Marks a match report as completed/finished

## Improvements
- Updated the  endpoint to use the dedicated  method instead of extracting events from the match data
- Added comprehensive tests for all new endpoints
- Updated the README.md with documentation for the new endpoints

## Related Issues
Closes #25

## Testing
All tests are passing. Run the following command to verify:
