### PR TITLE
Fix: Ensure all IDs are handled as integers throughout the codebase

### DIFF
--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -291,6 +291,32 @@ class FogisApiClient:
 
         return self._api_request(result_url, payload)
 
+    def report_match_result(self, result_data):
+        """
+        Reports match results (halftime and fulltime) to the FOGIS API.
+
+        Args:
+            result_data (dict): Data containing match results. Should include:
+                - matchid (int): The ID of the match
+                - hemmamal (int): Full-time score for the home team
+                - bortamal (int): Full-time score for the away team
+                - halvtidHemmamal (int, optional): Half-time score for the home team
+                - halvtidBortamal (int, optional): Half-time score for the away team
+
+        Returns:
+            dict: Response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+        """
+        # Ensure matchid is an integer
+        if 'matchid' in result_data:
+            result_data['matchid'] = int(result_data['matchid'])
+
+        result_url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista"
+        return self._api_request(result_url, result_data)
+
     def delete_match_event(self, event_id: int):
         """
         Deletes a specific event from a match.

--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -216,12 +216,12 @@ class FogisApiClient:
 
         return self._api_request(url, payload)
 
-    def fetch_team_players_json(self, team_id):
+    def fetch_team_players_json(self, team_id: int):
         """
         Fetches player information for a specific team.
 
         Args:
-            team_id (str): The ID of the team
+            team_id (int): The ID of the team
 
         Returns:
             dict: Player information for the team
@@ -231,16 +231,16 @@ class FogisApiClient:
             FogisAPIRequestError: If there's an error with the API request
         """
         url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/HamtaLagSpelare"
-        payload = {"lagid": team_id}
+        payload = {"lagid": int(team_id)}
 
         return self._api_request(url, payload)
 
-    def fetch_team_officials_json(self, team_id):
+    def fetch_team_officials_json(self, team_id: int):
         """
         Fetches officials information for a specific team.
 
         Args:
-            team_id (str): The ID of the team
+            team_id (int): The ID of the team
 
         Returns:
             dict: Officials information for the team
@@ -250,7 +250,7 @@ class FogisApiClient:
             FogisAPIRequestError: If there's an error with the API request
         """
         url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/HamtaLagFunktionarer"
-        payload = {"lagid": team_id}
+        payload = {"lagid": int(team_id)}
 
         return self._api_request(url, payload)
 

--- a/fogis_api_gateway.py
+++ b/fogis_api_gateway.py
@@ -235,7 +235,7 @@ def team_players(team_id):
     Endpoint to fetch player information for a specific team.
     """
     try:
-        players_data = client.fetch_team_players_json(team_id)
+        players_data = client.fetch_team_players_json(int(team_id))
         return jsonify(players_data)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -247,7 +247,7 @@ def team_officials(team_id):
     Endpoint to fetch officials information for a specific team.
     """
     try:
-        officials_data = client.fetch_team_officials_json(team_id)
+        officials_data = client.fetch_team_officials_json(int(team_id))
         return jsonify(officials_data)
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/tests/test_fogis_api_client.py
+++ b/tests/test_fogis_api_client.py
@@ -338,6 +338,63 @@ class TestFogisApiClient(unittest.TestCase):
             {"matchid": 12345}
         )
 
+    def test_report_match_result(self):
+        """Unit test for report_match_result method."""
+        # Mock the _api_request method
+        self.client._api_request = MagicMock(return_value={"success": True})
+
+        # Call report_match_result
+        result_data = {
+            "matchid": "12345",
+            "hemmamal": 2,
+            "bortamal": 1,
+            "halvtidHemmamal": 1,
+            "halvtidBortamal": 0
+        }
+        response = self.client.report_match_result(result_data)
+
+        # Verify the result
+        self.assertEqual(response, {"success": True})
+
+        # Verify the API call
+        self.client._api_request.assert_called_once_with(
+            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista",
+            {
+                "matchid": 12345,  # Should be converted to int
+                "hemmamal": 2,
+                "bortamal": 1,
+                "halvtidHemmamal": 1,
+                "halvtidBortamal": 0
+            }
+        )
+
+    def test_report_match_result_error(self):
+        """Unit test for report_match_result method with error."""
+        # Mock the _api_request method to raise an exception
+        self.client._api_request = MagicMock(side_effect=FogisAPIRequestError("API request failed"))
+
+        # Call report_match_result and expect an exception
+        result_data = {
+            "matchid": "12345",
+            "hemmamal": 2,
+            "bortamal": 1
+        }
+        with self.assertRaises(FogisAPIRequestError) as excinfo:
+            self.client.report_match_result(result_data)
+
+        # Verify the exception message
+        self.assertIn("API request failed", str(excinfo.exception))
+
+        # Verify the API call
+        self.client._api_request.assert_called_once_with(
+            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista",
+            {
+                "matchid": 12345,  # Should be converted to int
+                "hemmamal": 2,
+                "bortamal": 1
+            }
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes several issues:

1. Ensures all IDs (match IDs, team IDs, etc.) are handled as integers throughout the codebase
2. Updates the API gateway to convert string IDs from URLs to integers
3. Restores the accidentally removed methods: fetch_match_result_json and report_match_result
4. Adds comprehensive tests for the restored methods to prevent future accidental removal

This PR ensures that all IDs are properly converted to integers before being passed to the API, which should prevent issues with the API expecting integers but receiving strings.