### PR TITLE
Fix: Restore event_types dictionary that was accidentally removed

### DIFF
--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -8,6 +8,26 @@ import time
 import os
 from urllib.parse import urlparse, parse_qs
 
+# Event types dictionary for match events
+event_types = {  # Consistent Integer Keys for ALL event types (where applicable)
+    6: {"name": "Regular Goal", "goal": True},
+    39: {"name": "Header Goal", "goal": True},
+    28: {"name": "Corner Goal", "goal": True},
+    29: {"name": "Free Kick Goal", "goal": True},
+    15: {"name": "Own Goal", "goal": True},
+    14: {"name": "Penalty Goal", "goal": True},
+    18: {"name": "Penalty Missing Goal", "goal": False},
+    19: {"name": "Penalty Save", "goal": False},
+    26: {"name": "Penalty Hitting the Frame", "goal": False},
+    20: {"name": "Yellow Card", "goal": False},
+    8: {"name": "Red Card (Denying Goal Opportunity)", "goal": False},
+    9: {"name": "Red Card (Other Reasons)", "goal": False},
+    17: {"name": "Substitution", "goal": False},
+    31: {"name": "Period Start", "goal": False, "control_event": True},
+    32: {"name": "Period End", "goal": False, "control_event": True},
+    23: {"name": "Match Slut", "goal": False, "control_event": True}
+}
+
 # Custom exceptions
 class FogisLoginError(Exception):
     """Exception raised when login to FOGIS fails."""

--- a/tests/test_fogis_api_client.py
+++ b/tests/test_fogis_api_client.py
@@ -395,6 +395,31 @@ class TestFogisApiClient(unittest.TestCase):
             }
         )
 
+    def test_event_types_dictionary(self):
+        """Test that the event_types dictionary is present and properly formatted."""
+        from fogis_api_client.fogis_api_client import event_types
+
+        # Check that event_types is a dictionary
+        self.assertIsInstance(event_types, dict)
+
+        # Check that it has the expected keys and structure
+        self.assertIn(6, event_types)  # Regular Goal
+        self.assertIn(20, event_types)  # Yellow Card
+        self.assertIn(17, event_types)  # Substitution
+
+        # Check the structure of an entry
+        self.assertIn("name", event_types[6])
+        self.assertIn("goal", event_types[6])
+        self.assertEqual(event_types[6]["name"], "Regular Goal")
+        self.assertTrue(event_types[6]["goal"])
+
+        # Check a non-goal event
+        self.assertFalse(event_types[20]["goal"])
+
+        # Check a control event
+        self.assertIn("control_event", event_types[31])
+        self.assertTrue(event_types[31]["control_event"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR restores the event_types dictionary that was accidentally removed between versions 0.0.5 and 0.0.6. The event_types dictionary is important for handling match events and their types.

Changes:
1. Restored the event_types dictionary with all the original event types and their properties
2. Added a comprehensive test to ensure the event_types dictionary is present and properly formatted

This will ensure that the event_types dictionary doesn't get accidentally removed again in the future.