### PR TITLE
Fix: Configure pre-commit hooks to handle line length issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 6.0.0
     hooks:
     -   id: flake8
-        args: [--max-line-length=100, --extend-ignore=E203]
+        args: [--max-line-length=100, --extend-ignore=E203]  # Ignore whitespace before ':' for Black compatibility
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
-        args: [--max-line-length=100]
-
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -24,6 +18,12 @@ repos:
     hooks:
     -   id: black
         args: [--line-length=100]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        args: [--max-line-length=100, --extend-ignore=E203]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0

--- a/fogis_api_client/match_list_filter.py
+++ b/fogis_api_client/match_list_filter.py
@@ -47,7 +47,7 @@ class MatchListFilter:
         return self
 
     def saved_datum(self, saved_datum: str) -> "MatchListFilter":
-        """Sets the saved date for filter (likely not server-side, but included for completeness)."""
+        """Sets the saved date for filter (not server-side, included for completeness)."""
 
         self._sparad_datum = saved_datum
         return self

--- a/fogis_api_client_http_wrapper.py
+++ b/fogis_api_client_http_wrapper.py
@@ -156,7 +156,7 @@ def matches():
         if limit:
             try:
                 limit = int(limit)
-                matches_list = matches_list[offset:offset + limit]
+                matches_list = matches_list[offset : offset + limit]
             except ValueError:
                 pass  # Ignore invalid limit values
         elif offset > 0:
@@ -270,7 +270,7 @@ def match_events(match_id):
         if limit:
             try:
                 limit = int(limit)
-                events_data = events_data[offset:offset + limit]
+                events_data = events_data[offset : offset + limit]
             except ValueError:
                 pass  # Ignore invalid limit values
         elif offset > 0:
@@ -373,7 +373,7 @@ def team_players(team_id):
         if limit:
             try:
                 limit = int(limit)
-                players_data = players_data[offset:offset + limit]
+                players_data = players_data[offset : offset + limit]
             except ValueError:
                 pass  # Ignore invalid limit values
         elif offset > 0:
@@ -430,7 +430,7 @@ def team_officials(team_id):
         if limit:
             try:
                 limit = int(limit)
-                officials_data = officials_data[offset:offset + limit]
+                officials_data = officials_data[offset : offset + limit]
             except ValueError:
                 pass  # Ignore invalid limit values
         elif offset > 0:


### PR DESCRIPTION
This PR fixes the pre-commit hook issues related to line length by:

1. Reordering the pre-commit hooks to ensure Black runs before flake8
2. Fixing line length issues in multiple files:
   - Split return type annotations across multiple lines in fogis_api_client.py
   - Improved docstring formatting
   - Shortened overly long docstrings
3. Updated flake8 configuration to ignore E203 (whitespace before ':'), which is a style choice that Black makes deliberately

These changes ensure that all pre-commit hooks pass successfully and maintain consistent code quality throughout the project.

Updated to trigger CI workflow.