### PR TITLE
Fix: Update CI workflow to run on develop branch PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test and Publish
 
 on:
   push:
-    branches: [ "main", "feature/*" ]
+    branches: [ "main", "develop", "feature/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   release:
     types: [published]  # Trigger when a release is published
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow configuration to run CI tests on pull requests targeting the develop branch.

## Changes Made

1. Added 'develop' to the list of branches that trigger the workflow on push events
2. Added 'develop' to the list of branches that trigger the workflow on pull request events

This change ensures that CI tests will run automatically for all PRs targeting the develop branch, which is the integration branch according to our GitFlow process.

This will help catch issues earlier in the development process and ensure that all code merged into develop passes the required tests.