### PR TITLE
Fix: Configure pre-commit hooks to handle line length issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
-        args: [--max-line-length=100]
-
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -24,6 +18,12 @@ repos:
     hooks:
     -   id: black
         args: [--line-length=100]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        args: [--max-line-length=100, --extend-ignore=E203]  # Ignore whitespace before ':' for Black compatibility
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0

--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -75,7 +75,8 @@ class FogisApiClient:
         Args:
             username (Optional[str]): FOGIS username. Required if cookies are not provided.
             password (Optional[str]): FOGIS password. Required if cookies are not provided.
-            cookies (Optional[Dict[str, str]]): Session cookies for authentication. If provided, username and password are not required.
+            cookies (Optional[Dict[str, str]]): Session cookies for authentication.
+                If provided, username and password are not required.
 
         Raises:
             ValueError: If neither valid credentials nor cookies are provided
@@ -413,7 +414,8 @@ class FogisApiClient:
             return response_data
         else:
             raise FogisDataError(
-                f"Expected dictionary or list response but got {type(response_data).__name__}: {response_data}"
+                f"Expected dictionary or list response but got "
+                f"{type(response_data).__name__}: {response_data}"
             )
 
     def report_match_result(self, result_data: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
This PR fixes the pre-commit hook issues related to line length by:

1. Reordering the pre-commit hooks to ensure Black runs before flake8
2. Fixing line length issues in multiple files:
   - Split return type annotations across multiple lines
   - Improved docstring formatting
   - Shortened overly long docstrings
3. Updated flake8 configuration to ignore E203 (whitespace before ':'), which is a style choice that Black makes deliberately

These changes ensure that all pre-commit hooks pass successfully and maintain consistent code quality throughout the project.