### PR TITLE
Fix: Correct redirect URL handling in login method

### DIFF
--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -264,8 +264,16 @@ class FogisApiClient:
             # Handle the redirect manually for better control
             if response.status_code == 302 and "FogisMobilDomarKlient.ASPXAUTH" in response.cookies:
                 redirect_url = response.headers["Location"]
+
+                # Fix the redirect URL - the issue is here
                 if redirect_url.startswith("/"):
-                    redirect_url = f"{FogisApiClient.BASE_URL}{redirect_url}"
+                    # If it starts with /mdk/mdk/, we need to fix it
+                    if redirect_url.startswith("/mdk/mdk/"):
+                        redirect_url = redirect_url.replace("/mdk/mdk/", "/mdk/")
+
+                    # Now construct the full URL
+                    base = "https://fogis.svenskfotboll.se"
+                    redirect_url = f"{base}{redirect_url}"
 
                 self.logger.debug(f"Following redirect to {redirect_url}")
                 redirect_response = self.session.get(redirect_url, headers=headers)


### PR DESCRIPTION
# Fix: Correct redirect URL handling in login method

## Description
This PR fixes a critical bug in the login functionality where the redirect URL was not being properly handled, causing a 404 error after successful authentication.

## Issue
After successful authentication, the client was trying to follow a redirect to `/mdk/mdk/` which resulted in a 404 error because of the duplicated path segment.

## Fix
The fix includes:
1. Detecting and fixing the problematic `/mdk/mdk/` path duplication
2. Using the full base URL (`https://fogis.svenskfotboll.se`) instead of just the BASE_URL constant
3. Properly constructing the redirect URL

## Testing
- Tested with real credentials and confirmed successful login
- The login process now correctly follows the redirect and establishes a valid session

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
