### PR TITLE
HOTFIX: Fix parameter names in team endpoints

### DIFF
--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -33,8 +33,8 @@ https://fogis.svenskfotboll.se/mdk
 
 | Endpoint | Method | Description | Parameters |
 |----------|--------|-------------|------------|
-| `/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag` | POST | Fetches the list of players for a team | `lagid`: Integer |
-| `/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag` | POST | Fetches the list of officials for a team | `lagid`: Integer |
+| `/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag` | POST | Fetches the list of players for a team | `matchlagid`: Integer |
+| `/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag` | POST | Fetches the list of officials for a team | `matchlagid`: Integer |
 
 ## Event Endpoints
 

--- a/docs/user_guides/team_management.md
+++ b/docs/user_guides/team_management.md
@@ -36,8 +36,10 @@ except FogisLoginError as e:
 
 To get information about players in a team:
 
+> **Note**: The `team_id` parameter must be a match-specific team ID (`matchlagid`), not just the general team ID. You can get this ID from a match object's `hemmalagid` or `bortalagid` properties.
+
 ```python
-team_id = 12345  # Replace with your team ID
+team_id = 12345  # Replace with your team's match-specific ID (matchlagid)
 
 try:
     team_players_response = client.fetch_team_players_json(team_id)
@@ -65,6 +67,8 @@ except FogisAPIRequestError as e:
 ## Step 3: Fetch Team Officials
 
 To get information about team officials (coaches, managers, etc.):
+
+> **Note**: Just like with players, the `team_id` parameter must be a match-specific team ID (`matchlagid`), not just the general team ID.
 
 ```python
 try:

--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -582,7 +582,7 @@ class FogisApiClient:
         """
         url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag"
         team_id_int = int(team_id) if isinstance(team_id, (str, int)) else team_id
-        payload = {"lagid": team_id_int}
+        payload = {"matchlagid": team_id_int}
 
         response_data = self._api_request(url, payload)
 
@@ -628,7 +628,7 @@ class FogisApiClient:
         """
         url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag"
         team_id_int = int(team_id) if isinstance(team_id, (str, int)) else team_id
-        payload = {"lagid": team_id_int}
+        payload = {"matchlagid": team_id_int}
 
         response_data = self._api_request(url, payload)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="fogis-api-client-timmyBird",
-    version="0.2.3",
+    version="0.2.4",
     author="Bartek Svaberg",
     author_email="bartek.svaberg@gmail.com",
     description="A Python client for the FOGIS API (Svensk Fotboll)",


### PR DESCRIPTION
# HOTFIX: Fix parameter names in team endpoints

## Description
This PR fixes an issue with the parameter names in the team endpoints. The FOGIS API expects `matchlagid` as the parameter name for both `GetMatchdeltagareListaForMatchlag` and `GetMatchlagledareListaForMatchlag` endpoints, but our client was incorrectly using `lagid`.

## Changes
- Changed parameter name from `lagid` to `matchlagid` in `fetch_team_players_json` method
- Changed parameter name from `lagid` to `matchlagid` in `fetch_team_officials_json` method
- Updated documentation in `docs/api_endpoints.md` to reflect the correct parameter names
- Updated `docs/user_guides/team_management.md` to clarify the use of match-specific team IDs
- Updated version to 0.2.4 in `setup.py`
- Updated `CHANGELOG.md` with the new version and changes

## Related Issue
This PR addresses the issue where the client was failing with 500 errors when calling the team endpoints.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
Created a minimal test script that directly tests the API endpoints with the correct parameter names, and it successfully fetched both players and officials data.

## Note
The unit tests are currently failing because they expect the old parameter name. A separate issue (#99) has been created to update the tests and mock server to use the correct parameter names.
