### PR TITLE
Add reminders about CONTRIBUTING.md to issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,3 +32,7 @@ assignees: ''
 
 ## Possible Solution
 <!-- If you have suggestions on how to fix the issue -->
+
+## Contributing Guidelines
+<!-- Please make sure you've read and understood our CONTRIBUTING.md file before submitting this issue -->
+- [ ] I have read and agree to follow the [Contributing Guidelines](../../CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,3 +20,7 @@ assignees: ''
 
 ## Additional Context
 <!-- Add any other context, screenshots, or examples about the feature request here -->
+
+## Contributing Guidelines
+<!-- Please make sure you've read and understood our CONTRIBUTING.md file before submitting this feature request -->
+- [ ] I have read and agree to follow the [Contributing Guidelines](../../CONTRIBUTING.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@
 - [ ] I have verified that API endpoints still work as expected
 - [ ] I have checked for backward compatibility
 - [ ] I have added type hints where appropriate
-- [ ] I have followed the style guidelines in the CONTRIBUTING.md file
+- [ ] I have read and followed the guidelines in the [CONTRIBUTING.md](../CONTRIBUTING.md) file
 - [ ] I have reviewed my own code before submitting
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -442,7 +442,13 @@ If you are an AI assistant reading this:
    - When in doubt, ask for clarification rather than making assumptions
    - Consider creating templates for common tasks to ensure consistency
 
-8. **Remind Users of the Process**:
+8. **Include Reminders in Issues and PRs**:
+   - All issues and pull requests should include a reminder about following these guidelines
+   - Issue templates and PR templates have checkboxes to confirm reading this document
+   - When creating issues or PRs manually, include a link to this document
+   - This ensures consistency across all contributions, regardless of who handles them
+
+9. **Remind Users of the Process**:
    - If a user asks you to push directly to main, remind them of the GitFlow process
    - Suggest creating a proper branch and PR instead
    - Reference this document when explaining the process


### PR DESCRIPTION
## Description
This PR adds reminders about following the CONTRIBUTING.md guidelines to issue templates and the PR template.

## Related Issue
Fixes #102

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have read and followed the guidelines in the [CONTRIBUTING.md](../CONTRIBUTING.md) file
- [x] I have updated the documentation
- [x] I have followed the style guidelines in the CONTRIBUTING.md file
- [x] I have reviewed my own code before submitting

## Changes Made
1. **Updated issue templates**:
   - Added a Contributing Guidelines section to bug_report.md
   - Added a Contributing Guidelines section to feature_request.md
   - Added checkboxes to confirm reading the CONTRIBUTING.md file

2. **Updated PR template**:
   - Enhanced the existing checkbox for CONTRIBUTING.md with a direct link

3. **Updated CONTRIBUTING.md**:
   - Added a new section about including reminders in issues and PRs
   - Emphasized the importance of consistency across all contributions

## Additional Notes
These changes ensure that all contributors (human and AI) are reminded to follow the project guidelines, maintaining consistency across all contributions regardless of who handles which part of the process.