### PR TITLE
Implement parameterized tests for similar test cases (Issue #166)

### DIFF
--- a/integration_tests/test_api_endpoints.py
+++ b/integration_tests/test_api_endpoints.py
@@ -92,30 +92,36 @@ def test_root_endpoint():
     assert "FOGIS API Gateway" in data["message"]
 
 
-def test_matches_endpoint():
-    """Test the /matches endpoint returns a list of matches."""
+@pytest.mark.parametrize(
+    "endpoint,path_param,expected_type",
+    [
+        ("/matches", None, list),
+        ("/match", "1", dict),
+    ],
+    ids=["matches_endpoint", "match_details_endpoint"],
+)
+def test_api_endpoints(endpoint, path_param, expected_type):
+    """Test various API endpoints return valid responses.
+
+    Args:
+        endpoint: The API endpoint to test (without the base URL)
+        path_param: Optional path parameter to append to the endpoint
+        expected_type: The expected type of the response data (list or dict)
+    """
+    # Construct the full URL
+    url = f"{API_URL}{endpoint}"
+    if path_param:
+        url = f"{url}/{path_param}"
+
     # This endpoint might return an error if not authenticated
     # We'll just check that it returns a valid response
-    response = requests.get(f"{API_URL}/matches")
+    response = requests.get(url)
     assert response.status_code in [200, 500]  # Either success or error is acceptable
 
     # If successful, check the structure
     if response.status_code == 200:
         data = response.json()
-        assert isinstance(data, list)
-
-
-def test_match_details_endpoint():
-    """Test the /match/<match_id> endpoint returns match details."""
-    # This endpoint might return an error if not authenticated
-    # We'll just check that it returns a valid response
-    response = requests.get(f"{API_URL}/match/1")
-    assert response.status_code in [200, 500]  # Either success or error is acceptable
-
-    # If successful, check that it's a dict
-    if response.status_code == 200:
-        data = response.json()
-        assert isinstance(data, dict)
+        assert isinstance(data, expected_type)
 
 
 if __name__ == "__main__":

--- a/integration_tests/test_match_result_reporting.py
+++ b/integration_tests/test_match_result_reporting.py
@@ -196,8 +196,38 @@ class TestMatchResultReporting:
                 },
                 True,
             ),
+            # Abandoned match test case
+            (
+                "abandoned_match",
+                {
+                    "matchresultatListaJSON": [
+                        {
+                            "matchid": 12345,
+                            "matchresultattypid": 1,  # Full time
+                            "matchlag1mal": 1,
+                            "matchlag2mal": 1,
+                            "wo": False,
+                            "ow": False,
+                            "ww": True,  # Abandoned match
+                        }
+                    ]
+                },
+                True,
+            ),
+            # High score test case
+            (
+                "high_score",
+                {
+                    "matchid": 12345,
+                    "hemmamal": 10,
+                    "bortamal": 0,
+                    "halvtidHemmamal": 5,
+                    "halvtidBortamal": 0,
+                },
+                True,
+            ),
         ],
-        ids=["extra_time", "penalties", "walkover"],
+        ids=["extra_time", "penalties", "walkover", "abandoned_match", "high_score"],
     )
     def test_report_match_result_special_cases(
         self,


### PR DESCRIPTION
# Implement Parameterized Tests for Similar Test Cases

This PR implements parameterized tests for similar test cases in the integration tests, addressing Issue #166.

## Changes

- Refactored similar test cases in `test_with_mock_server.py` to use pytest's parameterization:
  - Combined login success/failure tests into a single parameterized test
  - Combined fetch match data tests (details, players, officials) into a parameterized test
  - Combined fetch team data tests (players, officials) into a parameterized test

- Refactored similar endpoint tests in `test_api_endpoints.py` to use parameterization:
  - Combined matches and match details endpoint tests into a parameterized test

- Enhanced `test_match_result_reporting.py` with additional test cases:
  - Added "abandoned match" and "high score" test cases to the existing parameterized test

## Benefits

- Reduced code duplication
- Made it easier to add new test cases
- Improved test coverage by encouraging more test scenarios
- Made the test suite more maintainable
- Provided clearer documentation of test scenarios

## Testing

All tests have been run and pass successfully.

Closes #166
